### PR TITLE
Add backend-generic sparse jacobian derivations

### DIFF
--- a/sym/backend.py
+++ b/sym/backend.py
@@ -3,8 +3,9 @@ from __future__ import (absolute_import, division, print_function)
 
 import os
 import sys
+import numpy as np
 
-from .util import banded_jacobian
+from .util import banded_jacobian, sparse_jacobian_csc, sparse_jacobian_csr
 
 
 def _DenseMatrix(be, *args, **kwargs):
@@ -24,6 +25,22 @@ class _Base(object):
         """ Wraps Matrix around result of .util.banded_jacobian """
         exprs = banded_jacobian(exprs, dep, ml, mu)
         return self.Matrix(ml+mu+1, len(dep), list(exprs.flat))
+
+    def sparse_jacobian_csc(self, exprs, dep):
+        """ Wraps Matrix/ndarray around results of .util.sparse_jacobian_csc """
+        jac_exprs, colptrs, rowvals = sparse_jacobian_csc(exprs, dep)
+        nnz = len(jac_exprs)
+        return self.Matrix(1, nnz, jac_exprs),\
+               np.asarray(colptrs, dtype=int),\
+               np.asarray(rowvals, dtype=int)
+
+    def sparse_jacobian_csr(self, exprs, dep):
+        """ Wraps Matrix/ndarray around results of .util.sparse_jacobian_csr """
+        jac_exprs, rowptrs, colvals = sparse_jacobian_csr(exprs, dep)
+        nnz = len(jac_exprs)
+        return self.Matrix(1, nnz, jac_exprs),\
+               np.asarray(rowptrs, dtype=int),\
+               np.asarray(colvals, dtype=int)
 
 
 class _SymPy(_Base):

--- a/sym/tests/test_sparse_jacobian.py
+++ b/sym/tests/test_sparse_jacobian.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function)
+
+import numpy as np
+import pytest
+
+from .. import Backend
+from . import AVAILABLE_BACKENDS
+
+
+@pytest.mark.parametrize('key', AVAILABLE_BACKENDS)
+def test_sparse_jacobian_csr(key):
+    be = Backend(key)
+    n = 3
+    x = be.real_symarray('x', n)
+    exprs = [-x[0]] + [x[i-1] - x[i] for i in range(1, n-1)] + [x[-2]]
+    sj, colptrs, rowvals = be.sparse_jacobian_csc(exprs, x)
+    cb = be.Lambdify(x, sj)
+    inp = np.arange(3.0, 3.0 + n)
+    out = cb(inp)
+    assert np.allclose(out, [-1, 1, -1, 1])
+    assert np.all(colptrs == np.array([0, 2, 4, 4], dtype=int))
+    assert np.all(rowvals == np.array([0, 1, 1, 2], dtype=int))
+
+
+@pytest.mark.parametrize('key', AVAILABLE_BACKENDS)
+def test_sparse_jacobian_csc(key):
+    be = Backend(key)
+    n = 3
+    x = be.real_symarray('x', n)
+    exprs = [-x[0]] + [x[i-1] - x[i] for i in range(1, n-1)] + [x[-2]]
+    sj, rowptrs, colvals = be.sparse_jacobian_csr(exprs, x)
+    cb = be.Lambdify(x, sj)
+    inp = np.arange(3.0, 3.0 + n)
+    out = cb(inp)
+    assert np.allclose(out, [-1, 1, -1, 1])
+    assert np.all(rowptrs == np.array([0, 1, 3, 4], dtype=int))
+    assert np.all(colvals == np.array([0, 0, 1, 1], dtype=int))


### PR DESCRIPTION
Should work for all backends, although I expect it will be faster in backends for which expressions have `free_symbols` available.